### PR TITLE
Improve sidebar toggle button positioning and style

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,8 +164,16 @@ body {
     .sidebar:not(.collapsed) ~ .main .sidebar-toggle {
         background-color: var(--primary-light) !important;
         color: var(--primary-color) !important;
-        position: absolute !important;
-        right: 55px !important;
+        position: fixed !important;
+        top: 24px !important;
+        left: calc(85% - 50px) !important; /* Moved more to the left for better visibility */
+        z-index: 1100 !important;
+        transition: all 0.3s ease !important;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1) !important;
+        /* border-radius: 50% !important; Make it round for better appearance */
+
+        width: 40px !important; /* Slightly larger button */
+        height: 40px !important;
     }
 
 }


### PR DESCRIPTION
Changed the sidebar toggle button from absolute to fixed positioning, adjusted its location for better visibility, and enhanced its appearance with size, sh
This pull request includes a change to the `style.css` file that improves the positioning, styling, and visibility of the `.sidebar-toggle` button when the sidebar is not collapsed.

Styling enhancements for `.sidebar-toggle`:

* Changed `position` from `absolute` to `fixed` and adjusted `top` and `left` properties to improve visibility and usability.
* Added `z-index`, `transition`, and `box-shadow` for better layering, smoother animations, and a more polished appearance.
* Increased the button's `width` and `height` to make it slightly larger and easier to interact with.adow, and transition effects.