### PR TITLE
Reduce base and body font sizes in CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@
     --radius-lg: 12px;
     --gradient-solar: linear-gradient(135deg, #9688E8 0%, #DAD7E8 100%);
     --gradient-header: linear-gradient(90deg, #9688E8 0%, #363636 100%);
-    font-size: 18px; /* Add this line for global scaling (was typically 16px) */
+    font-size: 14px; /* Add this line for global scaling (was typically 16px) */
 }
 
 * {
@@ -39,7 +39,7 @@ body {
     background-color: #F7F7F7;
     color: var(--text-primary);
     background-image: none;
-    font-size: 1.1rem; /* Increase from default (was 1rem) */
+    font-size: 1rem; /* Increase from default (was 1rem) */
 }
 
 /* Container Layout - Adding !important to ensure these styles take priority */
@@ -1429,8 +1429,6 @@ form button {
 }
 
 
-
-/* ////////////////////////////////////////////// */
 /* system-diagnosis css */
 
 
@@ -1723,7 +1721,7 @@ form button {
 }
 
 
-/* ////////////////////////////////////////// */
+
 /* user-managent css */
 
 


### PR DESCRIPTION
Decreased the root font size from 18px to 14px and the body font size from 1.1rem to 1rem for improved scaling and consistency. Also removed some unnecessary comment dividers.